### PR TITLE
Emit Events When no Filter is Set

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,7 +267,7 @@ where
                 event.record(&mut visitor);
                 visitor.perfetto
             })
-            .unwrap_or_default();
+            .unwrap_or(true);
 
         if !enabled {
             return;


### PR DESCRIPTION
Spans are currently emitted if no filter is explicitly set. This is different from the behaviour of events are only emitted if a filter explicitly enables them. This patch defaults to emitting events even if a filter isn't configured so that the behaviour of spans and events match.

I'm not sure if it's intentionally set up to not emit events by default, but fwiw, I found it confusing when I first took a trace and didn't find any events nor did I see documentation on how to emit them.

Here's the trace emitted from test/log.rs with and without the change
# Trace Before
![Trace Before](https://github.com/user-attachments/assets/0981868f-bb36-4e67-9745-5128b285a238)

# Trace After
![Trace After](https://github.com/user-attachments/assets/abdbe717-8c95-45b0-b486-39cff8a765cd)
