### PR TITLE
Implement Layer::on_record

### DIFF
--- a/tests/log.rs
+++ b/tests/log.rs
@@ -1,5 +1,5 @@
 use tokio::runtime::Handle;
-use tracing::{info, span, Level};
+use tracing::{field, info, span, Level};
 use tracing_perfetto::PerfettoLayer;
 use tracing_subscriber::fmt::format::Format;
 use tracing_subscriber::{fmt, layer::SubscriberExt, Registry};
@@ -21,7 +21,12 @@ async fn write() -> anyhow::Result<()> {
 
     info!(?file, "start");
 
-    let demo_span = span!(Level::TRACE, "demo_span");
+    let demo_span = span!(
+        Level::TRACE,
+        "demo_span",
+        regular_arg = "Arg data",
+        extra_arg = field::Empty
+    );
     let _enter = demo_span.enter();
 
     info!("in span");
@@ -33,6 +38,8 @@ async fn write() -> anyhow::Result<()> {
     t.join().unwrap();
 
     _ = tokio::spawn(async_fn()).await;
+    demo_span.record("extra_arg", "Some Extra Data");
+    demo_span.record("regular_arg", "New Arg Data");
     Ok(())
 }
 


### PR DESCRIPTION
Implements the Layer::on_record trait method which is called by `span.record(field, value)`. This allows
```
let span = trace_span!("span", later = field::Empty);
span.record("later", "data known later");
```
to work.

Testing:

Added

```
demo_span.record("extra_arg", "Some Extra Data");
demo_span.record("regular_arg", "New Arg Data");
```

To tests/log.rs. As far as I can tell, the test doesn't actually verify the output, but we do see:

```
2024-12-29T20:05:42.782580Z TRACE ThreadId(02) demo_span{regular_arg="Arg data" extra_arg="Some Extra Data" regular_arg="New Arg Data"}: log: exit
2024-12-29T20:05:42.782588Z TRACE ThreadId(02) demo_span{regular_arg="Arg data" extra_arg="Some Extra Data" regular_arg="New Arg Data"}: log: close time.busy=1.00s time.idle=24.1µs
test write ... ok
```

appear in the log now.

We also see that the argument is successfully updated when viewed by perfetto:
```
$ traceconv json /tmp/test.pftrace 2> /dev/null | jq '.traceEvents | .[] | select (.name == "demo_span")'
{
  "args": {
    "extra_arg": "Some Extra Data",
    "regular_arg": "New Arg Data",
    "source_location": {
      "file_name": "tests/log.rs",
      "line_number": 24
    }
  },
  "cat": "",
  "dur": 1002889,
  "name": "demo_span",
  "ph": "X",
  "pid": 24755,
  "tid": -1454467392,
  "ts": 1735503634309190
}
```