### PR TITLE
added support for user defined tracks via the 'perfetto.track_name' field

### DIFF
--- a/examples/threads_example.rs
+++ b/examples/threads_example.rs
@@ -1,0 +1,72 @@
+use tracing::{info, span};
+use tracing_perfetto::PerfettoLayer;
+use tracing_subscriber::fmt::format::Format;
+use tracing_subscriber::{fmt, layer::SubscriberExt, Registry};
+
+fn init_subscriber() {
+    let trace_path = std::env::temp_dir().join("test.pftrace");
+    let trace_file = std::fs::File::create(&trace_path).unwrap();
+    let perfetto_layer =
+        PerfettoLayer::new(std::sync::Mutex::new(trace_file)).with_debug_annotations(true);
+
+    let fmt_layer = fmt::layer()
+        .with_writer(std::io::stdout)
+        .event_format(Format::default().with_thread_ids(true))
+        .with_span_events(fmt::format::FmtSpan::FULL);
+
+    let subscriber = Registry::default().with(fmt_layer).with(perfetto_layer);
+
+    tracing::subscriber::set_global_default(subscriber).unwrap();
+}
+fn main() {
+    init_subscriber();
+    let main_span = span!(tracing::Level::INFO, "main");
+    let _guard = main_span.enter();
+    info!("start threads example with tracing");
+    std::thread::sleep(std::time::Duration::from_millis(250));
+    let mut join_handles = Vec::new();
+
+    // threads with default track id
+    for i in 0..3 {
+        let jh = std::thread::spawn(move || {
+            let _guard = span!(tracing::Level::INFO, "thread", i).entered();
+            info!("thread started");
+            for j in 0..3 {
+                let _guard = span!(tracing::Level::INFO, "loop", i, j).entered();
+                std::thread::sleep(std::time::Duration::from_millis(250));
+                info!("thread inner loop");
+                std::thread::sleep(std::time::Duration::from_millis(250));
+            }
+            info!("thread finished");
+        });
+        join_handles.push(jh);
+    }
+
+    for i in 0..3 {
+        let jh = std::thread::spawn(move || {
+            let _guard = span!(
+                tracing::Level::INFO,
+                "thread",
+                i,
+                perfetto.track_name = format!("thread track {}", i)
+            )
+            .entered();
+            info!("thread started");
+            for j in 0..3 {
+                let _guard = span!(tracing::Level::INFO, "loop", i, j).entered();
+                std::thread::sleep(std::time::Duration::from_millis(250));
+                info!("thread inner loop");
+                std::thread::sleep(std::time::Duration::from_millis(250));
+            }
+            info!("thread finished");
+        });
+
+        join_handles.push(jh);
+    }
+
+    for jh in join_handles {
+        jh.join().unwrap();
+    }
+    info!("end threads example with tracing");
+    std::thread::sleep(std::time::Duration::from_millis(250));
+}

--- a/examples/tokio_example.rs
+++ b/examples/tokio_example.rs
@@ -1,0 +1,90 @@
+use tracing::{info, span, Instrument};
+use tracing_perfetto::PerfettoLayer;
+use tracing_subscriber::fmt::format::Format;
+use tracing_subscriber::{fmt, layer::SubscriberExt, Registry};
+
+fn init_subscriber() {
+    let trace_path = std::env::temp_dir().join("test.pftrace");
+    let trace_file = std::fs::File::create(&trace_path).unwrap();
+    let perfetto_layer =
+        PerfettoLayer::new(std::sync::Mutex::new(trace_file)).with_debug_annotations(true);
+
+    let fmt_layer = fmt::layer()
+        .with_writer(std::io::stdout)
+        .event_format(Format::default().with_thread_ids(true))
+        .with_span_events(fmt::format::FmtSpan::FULL);
+
+    let subscriber = Registry::default().with(fmt_layer).with(perfetto_layer);
+
+    tracing::subscriber::set_global_default(subscriber).unwrap();
+}
+#[tokio::main]
+async fn main() {
+    init_subscriber();
+    let _main_span = span!(tracing::Level::INFO, "main").entered();
+    info!("start tokio example with tracing");
+
+    let mut join_handles = Vec::new();
+
+    // example 1: instrument async handler chain with a dedicated span
+    for i in 0..5 {
+        let task = async move {
+            // info!("task ${i} started");
+            tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+            for j in 0..3 {
+                let _span = span!(tracing::Level::INFO, "loop", i, j);
+
+                tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                info!("task ${i} inner loop");
+                tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+            info!("task ${i} finished");
+        };
+
+        let span = span!(
+            tracing::Level::INFO,
+            "task",
+            i,
+            perfetto.track_name = format!("task track {}", i)
+        );
+        let jh = tokio::spawn(task.instrument(span.or_current()));
+        join_handles.push(jh);
+    }
+
+    // example 2: attach an async handler chain to the current entered span
+    // this can be useful if we spawn a task but do not want to create a new span for it
+    // but to attach it to the current active span
+    // (or do not have a span to attach to)
+    for i in 5..10 {
+        let task = async move {
+            info!("task ${i} started");
+            for j in 0..3 {
+                let _span = span!(tracing::Level::INFO, "loop", i, j);
+
+                tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                info!("task ${i} inner loop");
+                tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+            info!("task ${i} finished");
+        };
+
+        let _guard = span!(
+            tracing::Level::INFO,
+            "task",
+            i,
+            perfetto.track_name = format!("task track {}", i)
+        )
+        .entered();
+        // do some work on the span
+        let jh = tokio::spawn(task.in_current_span());
+        // do some work on the span
+        join_handles.push(jh);
+    }
+
+    for jh in join_handles {
+        jh.await.unwrap();
+    }
+    info!("end tokio example with tracing");
+}

--- a/src/idl_helpers.rs
+++ b/src/idl_helpers.rs
@@ -1,0 +1,121 @@
+use crate::idl;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+// This is thread safe, since duplicated descriptor will be combined into one by perfetto.
+static PROCESS_DESCRIPTOR_SENT: AtomicBool = AtomicBool::new(false);
+thread_local! {
+    static THREAD_TRACK_UUID: AtomicU64 = AtomicU64::new(unique_uuid());
+    static THREAD_DESCRIPTOR_SENT: AtomicBool = const { AtomicBool::new(false) };
+}
+
+#[derive(Default)]
+pub struct DebugAnnotations {
+    pub annotations: Vec<idl::DebugAnnotation>,
+}
+
+// static GLOBAL_COUNTER: AtomicU64 = AtomicU64::new(1);
+pub fn unique_uuid() -> u64 {
+    // generate random
+    rand::random()
+    // GLOBAL_COUNTER.fetch_add(1, Ordering::Relaxed)
+}
+
+pub fn current_thread_uuid() -> u64 {
+    THREAD_TRACK_UUID.with(|id| id.load(Ordering::Relaxed))
+}
+
+pub fn current_thread_descriptor() -> idl::ThreadDescriptor {
+    let mut thread = idl::ThreadDescriptor::default();
+    thread.pid = Some(std::process::id() as _);
+    thread.tid = Some(thread_id::get() as _);
+    thread.thread_name = std::thread::current().name().map(|n| n.to_string());
+    thread
+}
+
+pub fn current_thread_track_descriptor() -> idl::TrackDescriptor {
+    let thread_track_uuid = THREAD_TRACK_UUID.with(|id| id.load(Ordering::Relaxed));
+    let thread_desc = current_thread_descriptor().into();
+    let track_desc = create_track_descriptor(
+        thread_track_uuid.into(),
+        None,
+        std::thread::current().name(),
+        None,
+        thread_desc,
+        None,
+    );
+    track_desc
+}
+
+pub fn create_track_descriptor(
+    uuid: Option<u64>,
+    parent_uuid: Option<u64>,
+    name: Option<impl AsRef<str>>,
+    process: Option<idl::ProcessDescriptor>,
+    thread: Option<idl::ThreadDescriptor>,
+    counter: Option<idl::CounterDescriptor>,
+) -> idl::TrackDescriptor {
+    let mut desc = idl::TrackDescriptor::default();
+    desc.uuid = uuid;
+    desc.parent_uuid = parent_uuid;
+    desc.static_or_dynamic_name = name
+        .map(|s| s.as_ref().to_string())
+        .map(idl::track_descriptor::StaticOrDynamicName::Name);
+    desc.process = process;
+    desc.thread = thread;
+    desc.counter = counter;
+    desc
+}
+
+pub fn current_process_descriptor() -> idl::ProcessDescriptor {
+    let mut process = idl::ProcessDescriptor::default();
+    process.pid = Some(std::process::id() as _);
+    process
+}
+
+pub fn process_descriptor(process_track_uuid: u64) -> Option<idl::TracePacket> {
+    let process_first_frame_sent = PROCESS_DESCRIPTOR_SENT.fetch_or(true, Ordering::SeqCst);
+    if process_first_frame_sent {
+        return None;
+    }
+    let mut packet = idl::TracePacket::default();
+    let process = current_process_descriptor().into();
+    let track_desc = create_track_descriptor(
+        Some(process_track_uuid),
+        None,
+        None::<&str>,
+        process,
+        None,
+        None,
+    );
+    packet.data = Some(idl::trace_packet::Data::TrackDescriptor(track_desc));
+    Some(packet)
+}
+
+pub fn create_event(
+    track_uuid: u64,
+    name: Option<&str>,
+    location: Option<(&str, u32)>,
+    debug_annotations: DebugAnnotations,
+    r#type: Option<idl::track_event::Type>,
+) -> idl::TrackEvent {
+    let mut event = idl::TrackEvent::default();
+    event.track_uuid = Some(track_uuid);
+    event.categories = vec!["".to_string()];
+    if let Some(name) = name {
+        event.name_field = Some(idl::track_event::NameField::Name(name.to_string()));
+    }
+    if let Some(t) = r#type {
+        event.set_type(t);
+    }
+    if !debug_annotations.annotations.is_empty() {
+        event.debug_annotations = debug_annotations.annotations;
+    }
+    if let Some((file, line)) = location {
+        let mut source_location = idl::SourceLocation::default();
+        source_location.file_name = Some(file.to_owned());
+        source_location.line_number = Some(line);
+        let location = idl::track_event::SourceLocationField::SourceLocation(source_location);
+        event.source_location_field = Some(location);
+    }
+    event
+}


### PR DESCRIPTION


- library support for custom tracks via a new field 'prefetto.track_name'
- fallback to thread track if the field is not set
- user provided track propagates to child spans (useful in async)
- some examples illustrating usage