### PR TITLE
Take PerfettoWriter instead of MakeWriter in PerfettoLayer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,7 @@ impl Visit for PerfettoVisitor {
 impl<W, S: Subscriber> Layer<S> for PerfettoLayer<W>
 where
     S: for<'a> LookupSpan<'a>,
-    W: for<'writer> MakeWriter<'writer> + 'static,
+    W: PerfettoWriter + 'static,
 {
     fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
         let Some(span) = ctx.span(id) else {


### PR DESCRIPTION
This mirrors `impl<W: PerfettoWriter> PerfettoLayer<W>` we have.